### PR TITLE
Release 1.1.3

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^ru\.sh$
 ^cm\.sh$
 ^ca\.sh$
 ^revdep$

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 
 language: R
 cache: packages
+latex: false
 
 matrix:
   include:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fgeo.plot
 Title: Plot ForestGEO Data
-Version: 1.1.2.9000
+Version: 1.1.3
 Authors@R: 
     c(person(given = "Mauro",
              family = "Lepore",
@@ -19,7 +19,7 @@ Depends:
     R (>= 3.2)
 Imports: 
     dplyr (>= 0.7.8),
-    fgeo.tool (>= 1.2.1),
+    fgeo.tool (>= 1.2.2),
     ggplot2 (>= 3.1.0),
     ggrepel (>= 0.8.0),
     glue (>= 1.3.0),
@@ -30,7 +30,7 @@ Imports:
     stringr (>= 1.3.1)
 Suggests: 
     covr (>= 3.2.1),
-    fgeo.x (>= 1.1.0),
+    fgeo.x (>= 1.1.2),
     gridExtra (>= 2.3),
     knitr (>= 1.21),
     rmarkdown (>= 1.11),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,20 +2,9 @@
 
 * Work in progress.
 
-# fgeo.plot 1.1.2.9000 ([GitHub](https://github.com/forestgeo/fgeo.plot/releases) and [drat](https://forestgeo.github.io/drat/))
+# fgeo.plot 1.1.3 ([GitHub](https://github.com/forestgeo/fgeo.plot/releases) and [drat](https://forestgeo.github.io/drat/))
 
 * Require R >= 3.2.
-
-Developer facing:
-* Test on Travis CI on R >= 3.2.
-* Fix error `Error: 'hasName' is not an exported object from 'namespace:utils'`.
-
-
-
-* TODO: Build site automatically and move it to gh-pages.
-
-
-
 
 # fgeo.plot 1.1.2 ([GitHub](https://github.com/forestgeo/fgeo.plot/releases) and [drat](https://forestgeo.github.io/drat/))
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -8,11 +8,8 @@
 
 ## R CMD check results
 
-0 errors v | 1 warnings | 0 notes
+0 errors v | 1 warnings (safe to ignore) | 0 notes
 
-* This warning is safe to ignore.
-
-WARNING
 * New submission
 * Strong dependencies not in mainstream repositories:
   fgeo.tool


### PR DESCRIPTION
Developer-facing changes:
* Test on Travis CI on R >= 3.2.
* Fix error `Error: 'hasName' is not an exported object from 'namespace:utils'`.
* Build site automatically and move it to gh-pages.